### PR TITLE
Add state and device class to temp and humidity template sensors

### DIFF
--- a/assets/source/v1.0.5.yaml
+++ b/assets/source/v1.0.5.yaml
@@ -485,6 +485,8 @@ sensor:
     id: scd40_temp_corr
     name: "SCD40 Temperature"
     unit_of_measurement: "°C"
+    state_class: measurement
+    device_class: temperature
     accuracy_decimals: 2
     update_interval: 5s
     lambda: |-
@@ -495,6 +497,8 @@ sensor:
     id: scd40_rh_corr
     name: "SCD40 Humidity"
     unit_of_measurement: "%"
+    state_class: measurement
+    device_class: humidity
     accuracy_decimals: 1
     update_interval: 5s
     lambda: |-
@@ -546,6 +550,8 @@ sensor:
     id: bme_temp_corr
     name: "BME688 Temperature"
     unit_of_measurement: "°C"
+    state_class: measurement
+    device_class: temperature
     accuracy_decimals: 2
     update_interval: 5s
     lambda: |-
@@ -556,6 +562,8 @@ sensor:
     id: bme_rh_corr
     name: "BME688 Humidity"
     unit_of_measurement: "%"
+    state_class: measurement
+    device_class: humidity
     accuracy_decimals: 1
     update_interval: 5s
     lambda: |-


### PR DESCRIPTION
Since the temperature and humidity for the SCD40 and BME688 sensors are provided via template sensors, they are lacking a default device and state class. This prevents them from being displayed in the same statistics graph as other temperature and humidity sensors.

<img width="1281" height="1090" alt="image" src="https://github.com/user-attachments/assets/00219348-0c70-4dfc-a400-9d4f9cb24486" />
