### PR TITLE
Switch to native temperature_offsets for BME688 and SCD40

### DIFF
--- a/assets/source/main.yaml
+++ b/assets/source/main.yaml
@@ -544,68 +544,41 @@ sensor:
       unit_of_measurement: "ppm"
       icon: "mdi:molecule-co2"
     temperature:
-      name: "SCD40 Temperature Raw"
-      id: scd40_temp_raw
+      name: "SCD40 Temperature"
+      id: scd40_temp
       unit_of_measurement: "°C"
-      icon: "mdi:thermometer"
-      internal: true
+      state_class: measurement
+      device_class: temperature
+      accuracy_decimals: 2
     humidity:
-      name: "SCD40 Humidity Raw"
-      id: scd40_rh_raw
+      name: "SCD40 Humidity"
+      id: scd40_rh
       unit_of_measurement: "%"
-      icon: "mdi:water-percent"
-      internal: true
-
-  - platform: template
-    id: scd40_temp_corr
-    name: "SCD40 Temperature"
-    unit_of_measurement: "°C"
-    state_class: measurement
-    device_class: temperature
-    accuracy_decimals: 2
-    update_interval: 5s
-    lambda: |-
-      if (isnan(id(scd40_temp_raw).state)) return NAN;
-      return id(scd40_temp_raw).state - id(scd40_temperature_offset).state;
-
-  - platform: template
-    id: scd40_rh_corr
-    name: "SCD40 Humidity"
-    unit_of_measurement: "%"
-    state_class: measurement
-    device_class: humidity
-    accuracy_decimals: 1
-    update_interval: 5s
-    lambda: |-
-      const float Tm  = id(scd40_temp_raw).state;
-      const float Tc  = id(scd40_temp_corr).state;
-      const float RHm = id(scd40_rh_raw).state;
-      if (isnan(Tm) || isnan(Tc) || isnan(RHm)) return NAN;
-
-      auto es = [](float T) -> float {
-        return 6.1094f * expf(17.625f * T / (T + 243.04f));
-      };
-      float e = (RHm / 100.0f) * es(Tm);
-      float RHc = 100.0f * e / es(Tc);
-      if (RHc < 0.0f) RHc = 0.0f;
-      if (RHc > 100.0f) RHc = 100.0f;
-      return RHc;
+      state_class: measurement
+      device_class: humidity
+      accuracy_decimals: 1
 
   - platform: bme68x_bsec2
     temperature:
-      name: "BME688 Temperature Raw"
-      id: bme_temp_raw
-      internal: true
+      name: "BME688 Temperature"
+      id: bme_temp
+      unit_of_measurement: "°C"
+      state_class: measurement
+      device_class: temperature
+      accuracy_decimals: 2
       sample_rate: LP
     pressure:
       name: "BME688 Pressure"
       id: bme_pressure
       sample_rate: LP
     humidity:
-      name: "BME688 Humidity Raw"
-      id: bme_rh_raw
-      internal: true
+      name: "BME688 Humidity"
+      id: bme_rh
       sample_rate: LP
+      unit_of_measurement: "%"
+      state_class: measurement
+      device_class: humidity
+      accuracy_decimals: 1
     gas_resistance:
       name: "BME688 Gas Resistance (kΩ)"
       unit_of_measurement: "kΩ"
@@ -620,41 +593,6 @@ sensor:
       name: "BME688 CO₂ Equivalent"
     breath_voc_equivalent:
       name: "BME688 VOC Equivalent"
-
-  - platform: template
-    id: bme_temp_corr
-    name: "BME688 Temperature"
-    unit_of_measurement: "°C"
-    state_class: measurement
-    device_class: temperature
-    accuracy_decimals: 2
-    update_interval: 5s
-    lambda: |-
-      if (isnan(id(bme_temp_raw).state)) return NAN;
-      return id(bme_temp_raw).state - id(bme688_temperature_offset).state;
-
-  - platform: template
-    id: bme_rh_corr
-    name: "BME688 Humidity"
-    unit_of_measurement: "%"
-    state_class: measurement
-    device_class: humidity
-    accuracy_decimals: 1
-    update_interval: 5s
-    lambda: |-
-      const float Tm  = id(bme_temp_raw).state;
-      const float Tc  = id(bme_temp_corr).state;
-      const float RHm = id(bme_rh_raw).state;
-      if (isnan(Tm) || isnan(Tc) || isnan(RHm)) return NAN;
-
-      auto es = [](float T) -> float {
-        return 6.1094f * expf(17.625f * T / (T + 243.04f));
-      };
-      float e = (RHm / 100.0f) * es(Tm);
-      float RHc = 100.0f * e / es(Tc);
-      if (RHc < 0.0f) RHc = 0.0f;
-      if (RHc > 100.0f) RHc = 100.0f;
-      return RHc;
 
   - platform: ltr390
     i2c_id: i2c_bus
@@ -1666,6 +1604,10 @@ number:
     optimistic: true
     restore_value: true
     mode: box
+    on_value:
+      then:
+        - lambda: |-
+            id(scd40_sensor)->set_temperature_offset(x);
 
   - platform: template
     id: bme688_temperature_offset
@@ -1679,6 +1621,10 @@ number:
     optimistic: true
     restore_value: true
     mode: box
+    on_value:
+      then:
+        - lambda: |-
+            id(bsec_virtual_sensor)->set_temperature_offset(x);
 
   - platform: template
     id: ltr390_lux_offset


### PR DESCRIPTION
Remove manual temperature offset logic and replace with sensor internal offsets.
This works perfectly for BME688, but SCD40 requires a reboot after changing the offset - as it's only read once.