### PR TITLE
Add state_class to target count metrics

### DIFF
--- a/assets/source/main.yaml
+++ b/assets/source/main.yaml
@@ -641,6 +641,7 @@ sensor:
     icon: mdi:counter
     id: all_targets_count
     unit_of_measurement: ""
+    state_class: measurement
     update_interval: 1s
     lambda: |-
       int count = 0;
@@ -654,6 +655,7 @@ sensor:
     icon: mdi:counter
     id: zone1_target_count
     unit_of_measurement: ""
+    state_class: measurement
     update_interval: 1s
     lambda: |-
       const int MAX_PTS = 8;
@@ -694,6 +696,7 @@ sensor:
     icon: mdi:counter
     id: zone2_target_count
     unit_of_measurement: ""
+    state_class: measurement
     update_interval: 1s
     lambda: |-
       const int MAX_PTS = 8;
@@ -734,6 +737,7 @@ sensor:
     icon: mdi:counter
     id: zone3_target_count
     unit_of_measurement: ""
+    state_class: measurement
     update_interval: 1s
     lambda: |-
       const int MAX_PTS = 8;


### PR DESCRIPTION
Adds `state_class: measurement` to the four Target Count template sensors (All Targets Count, Zone 1/2/3 Target Count). Without a state class these integer counts aren't enrolled in long-term statistics, so longer history windows and the Statistics Graph card don't plot them as a continuous line, only discrete entries (logbook style). `measurement` fixes the graph rendering and persists the data past the short-term recorder purge. No unit or logic changes.