### PR TITLE
Change rgb_order to channel_colors in main.yaml

### DIFF
--- a/assets/source/main.yaml
+++ b/assets/source/main.yaml
@@ -289,7 +289,7 @@ light:
     chipset: WS2812
     pin: GPIO3
     num_leds: 1
-    rgb_order: GRB
+    channel_colors: GRB
     restore_mode: RESTORE_DEFAULT_OFF
     effects:
       - addressable_lambda:


### PR DESCRIPTION
rgb_order is deprecated since esphome 2026.8

```
WARNING [esp32_rmt_led_strip] 'rgb_order' is deprecated, use 'channel_colors: GRB'. Will be removed in 2027.3.0
```